### PR TITLE
Fix: SetTeam logic - Replace or add teams based on TeamNumber

### DIFF
--- a/EpinelPS/LobbyServer/Team/SetTeam.cs
+++ b/EpinelPS/LobbyServer/Team/SetTeam.cs
@@ -20,11 +20,57 @@ namespace EpinelPS.LobbyServer.Team
 
             // Add team data to user data
             NetUserTeamData teamData = new() { LastContentsTeamNumber = req.ContentsId + 1, Type = req.Type };
-            teamData.Teams.AddRange(req.Teams);
+
+            // Check for existing teams with same TeamNumber and replace or add accordingly
+            foreach (var newTeam in req.Teams)
+            {
+                bool teamUpdated = false;
+                for (int i = 0; i < teamData.Teams.Count; i++)
+                {
+                    if (teamData.Teams[i].TeamNumber == newTeam.TeamNumber)
+                    {
+                        // Replace existing team with same TeamNumber
+                        teamData.Teams[i] = newTeam;
+                        teamUpdated = true;
+                        break;
+                    }
+                }
+
+                if (!teamUpdated)
+                {
+                    // Add new team if TeamNumber doesn't exist
+                    teamData.Teams.Add(newTeam);
+                }
+            }
 
             if (!user.UserTeams.TryAdd(req.Type, teamData))
             {
-                user.UserTeams[req.Type] = teamData;
+                // If key already exists, we need to merge teams properly
+                var existingTeamData = user.UserTeams[req.Type];
+                existingTeamData.LastContentsTeamNumber = req.ContentsId + 1;
+                existingTeamData.Type = req.Type;
+
+                // Apply same logic to existing team data
+                foreach (var newTeam in req.Teams)
+                {
+                    bool teamUpdated = false;
+                    for (int i = 0; i < existingTeamData.Teams.Count; i++)
+                    {
+                        if (existingTeamData.Teams[i].TeamNumber == newTeam.TeamNumber)
+                        {
+                            // Replace existing team with same TeamNumber
+                            existingTeamData.Teams[i] = newTeam;
+                            teamUpdated = true;
+                            break;
+                        }
+                    }
+
+                    if (!teamUpdated)
+                    {
+                        // Add new team if TeamNumber doesn't exist
+                        existingTeamData.Teams.Add(newTeam);
+                    }
+                }
             }
 
             JsonDb.Save();


### PR DESCRIPTION
 Summary of Changes

  - File Modified: EpinelPS/LobbyServer/Team/SetTeam.cs
  - Core Fix: Implemented intelligent team replacement logic based on TeamNumber Issue Fixed

  Fixed the team management logic in the SetTeam handler to   
  properly:
  - ✅ Check if existing teams have the same TeamNumber
  - ✅ Replace teams with matching TeamNumber instead of  duplicating them
  - ✅ Add new teams with different TeamNumber to the  collection
  - ✅ Handle both new team creation and existing team data updates