### PR TITLE
Fix character skill upgrades and outpost reward currency updates

### DIFF
--- a/EpinelPS/LobbyServer/Character/SkillLevelUp.cs
+++ b/EpinelPS/LobbyServer/Character/SkillLevelUp.cs
@@ -1,5 +1,6 @@
 ﻿using EpinelPS.Data;
 using EpinelPS.Database;
+using EpinelPS.Utils;
 
 namespace EpinelPS.LobbyServer.Character;
 
@@ -12,44 +13,235 @@ public class SkillLevelUp : LobbyMessage
         User user = GetUser();
         ResCharacterSkillLevelUp response = new();
 
-        CharacterModel character = user.Characters.FirstOrDefault(c => c.Csn == req.Csn) ?? throw new Exception("cannot find character");
+        SkillLevelUpResult result = SkillLevelUpHelper.Upgrade(user, req.Csn, (CharacterSkillCategory)req.Category);
+        response.Character = result.Character;
+        response.Items.AddRange(result.Items);
+        response.Currencies.AddRange(result.Currencies);
 
-        CharacterRecord charRecord = GameData.Instance.CharacterTable.Values.FirstOrDefault(c => c.Id == character.Tid) ?? throw new Exception("cannot find character record");
-        Dictionary<int, int> skillIdMap = new()
+        JsonDb.Save();
+
+        await WriteDataAsync(response);
+    }
+}
+
+[GameRequest("/character/skill/levelupV2")]
+public class SkillLevelUpV2 : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqCharacterSkillLevelUpV2 req = await ReadData<ReqCharacterSkillLevelUpV2>();
+        User user = GetUser();
+        ResCharacterSkillLevelUpV2 response = new();
+
+        SkillLevelUpResult result = SkillLevelUpHelper.Upgrade(user, req.Csn, req.SkillCategory, req.TargetLevel);
+        response.Character = result.Character;
+        response.Items.AddRange(result.Items);
+        response.Currencies.AddRange(result.Currencies);
+
+        JsonDb.Save();
+
+        await WriteDataAsync(response);
+    }
+}
+
+internal class SkillLevelUpResult
+{
+    public NetUserCharacterDefaultData Character { get; set; } = new();
+    public List<NetUserItemData> Items { get; } = [];
+    public List<NetUserCurrencyData> Currencies { get; } = [];
+}
+
+internal static class SkillLevelUpHelper
+{
+    public static SkillLevelUpResult Upgrade(User user, long csn, CharacterSkillCategory category)
+    {
+        CharacterModel character = GetCharacter(user, csn);
+        return Upgrade(user, csn, category, GetSkillLevel(character, category) + 1);
+    }
+
+    public static SkillLevelUpResult Upgrade(User user, long csn, CharacterSkillCategory category, int targetLevel)
+    {
+        CharacterModel character = GetCharacter(user, csn);
+
+        if (category == CharacterSkillCategory.None)
         {
-            { 1, charRecord.UltiSkillId },
-            { 2, charRecord.Skill1Id },
-            { 3, charRecord.Skill2Id }
-        };
-        Dictionary<int, int> skillLevelMap = new()
+            throw new BadHttpRequestException("Skill category is required", 400);
+        }
+
+        int currentLevel = GetSkillLevel(character, category);
+        if (targetLevel <= currentLevel)
         {
-            { 1, character.UltimateLevel },
-            { 2, character.Skill1Lvl },
-            { 3, character.Skill2Lvl }
-        };
-        SkillInfoRecord skillRecord = GameData.Instance.skillInfoTable.Values.FirstOrDefault(s => s.Id == skillIdMap[req.Category] + (skillLevelMap[req.Category] - 1)) ?? throw new Exception("cannot find character skill record");
-        CostRecord costRecord = GameData.Instance.costTable.Values.FirstOrDefault(c => c.Id == skillRecord.LevelUpCostId) ?? throw new Exception("cannot find character cost record");
+            return new SkillLevelUpResult { Character = ToNetCharacter(character) };
+        }
 
-        foreach (CostData? cost in costRecord.Costs.Where(i => i.ItemType != RewardType.None))
+        if (targetLevel > 10)
         {
-            DbItemData item = user.Items.FirstOrDefault(i => i.ItemType == cost.ItemId) ?? throw new NullReferenceException();
+            throw new BadHttpRequestException($"Invalid target skill level {targetLevel}", 400);
+        }
 
-            item.Count -= cost.ItemValue;
+        int levelUpCount = targetLevel - currentLevel;
+        int baseSkillId = GetBaseSkillId(character, category);
+        Dictionary<int, int> itemCosts = [];
+        Dictionary<CurrencyType, long> currencyCosts = [];
 
-            response.Items.Add(new NetUserItemData
+        for (int level = currentLevel; level < targetLevel; level++)
+        {
+            int skillId = baseSkillId + level - 1;
+            if (!GameData.Instance.skillInfoTable.TryGetValue(skillId, out SkillInfoRecord? skillRecord))
             {
-                Isn = item.Isn,
-                Tid = cost.ItemId,
-                Count = item.Count,
-                Csn = item.Csn,
-                Corporation = item.Corp,
-                Lv = item.Level,
-                Exp = item.Exp,
-                Position = item.Position
+                throw new BadHttpRequestException($"Skill info {skillId} not found", 400);
+            }
+
+            if (skillRecord.LevelUpCostId == 0)
+            {
+                continue;
+            }
+
+            if (!GameData.Instance.costTable.TryGetValue(skillRecord.LevelUpCostId, out CostRecord? costRecord))
+            {
+                throw new BadHttpRequestException($"Skill cost {skillRecord.LevelUpCostId} not found", 400);
+            }
+
+            AddCosts(costRecord, itemCosts, currencyCosts);
+        }
+
+        EnsureEnoughResources(user, itemCosts, currencyCosts);
+
+        SkillLevelUpResult result = new();
+        DeductResources(user, itemCosts, currencyCosts, result);
+
+        SetSkillLevel(character, category, targetLevel);
+        result.Character = ToNetCharacter(character);
+
+        user.AddTrigger(Trigger.CharacterSkillLevelUpCount, levelUpCount);
+        if (character.UltimateLevel == 10 && character.Skill1Lvl == 10 && character.Skill2Lvl == 10)
+        {
+            user.AddTrigger(Trigger.CharacterSkillLevelMax, 1);
+        }
+
+        return result;
+    }
+
+    private static CharacterModel GetCharacter(User user, long csn)
+    {
+        return user.Characters.FirstOrDefault(c => c.Csn == csn)
+            ?? throw new BadHttpRequestException($"Character with CSN {csn} not found", 404);
+    }
+
+    private static int GetBaseSkillId(CharacterModel character, CharacterSkillCategory category)
+    {
+        if (!GameData.Instance.CharacterTable.TryGetValue(character.Tid, out CharacterRecord? charRecord))
+        {
+            throw new BadHttpRequestException($"Character record {character.Tid} not found", 404);
+        }
+
+        return category switch
+        {
+            CharacterSkillCategory.Ultimate => charRecord.UltiSkillId,
+            CharacterSkillCategory.Skill1 => charRecord.Skill1Id,
+            CharacterSkillCategory.Skill2 => charRecord.Skill2Id,
+            _ => throw new BadHttpRequestException("Invalid skill category", 400)
+        };
+    }
+
+    private static int GetSkillLevel(CharacterModel character, CharacterSkillCategory category)
+    {
+        return category switch
+        {
+            CharacterSkillCategory.Ultimate => character.UltimateLevel,
+            CharacterSkillCategory.Skill1 => character.Skill1Lvl,
+            CharacterSkillCategory.Skill2 => character.Skill2Lvl,
+            _ => throw new BadHttpRequestException("Invalid skill category", 400)
+        };
+    }
+
+    private static void SetSkillLevel(CharacterModel character, CharacterSkillCategory category, int targetLevel)
+    {
+        switch (category)
+        {
+            case CharacterSkillCategory.Ultimate:
+                character.UltimateLevel = targetLevel;
+                break;
+            case CharacterSkillCategory.Skill1:
+                character.Skill1Lvl = targetLevel;
+                break;
+            case CharacterSkillCategory.Skill2:
+                character.Skill2Lvl = targetLevel;
+                break;
+            default:
+                throw new BadHttpRequestException("Invalid skill category", 400);
+        }
+    }
+
+    private static void AddCosts(CostRecord costRecord, Dictionary<int, int> itemCosts, Dictionary<CurrencyType, long> currencyCosts)
+    {
+        foreach (CostData cost in costRecord.Costs.Where(cost => cost.ItemType != RewardType.None && cost.ItemValue > 0))
+        {
+            if (cost.ItemType == RewardType.Currency)
+            {
+                CurrencyType type = (CurrencyType)cost.ItemId;
+                if (!currencyCosts.TryAdd(type, cost.ItemValue))
+                {
+                    currencyCosts[type] += cost.ItemValue;
+                }
+            }
+            else if (cost.ItemType == RewardType.Item)
+            {
+                if (!itemCosts.TryAdd(cost.ItemId, cost.ItemValue))
+                {
+                    itemCosts[cost.ItemId] += cost.ItemValue;
+                }
+            }
+            else
+            {
+                throw new BadHttpRequestException($"Unsupported skill level cost type {cost.ItemType}", 400);
+            }
+        }
+    }
+
+    private static void EnsureEnoughResources(User user, Dictionary<int, int> itemCosts, Dictionary<CurrencyType, long> currencyCosts)
+    {
+        foreach ((CurrencyType type, long value) in currencyCosts)
+        {
+            if (!user.CanSubtractCurrency(type, value))
+            {
+                throw new BadHttpRequestException($"Insufficient currency {type}. Required: {value}, Available: {user.GetCurrencyVal(type)}", 400);
+            }
+        }
+
+        foreach ((int tid, int count) in itemCosts)
+        {
+            DbItemData? item = user.Items.FirstOrDefault(item => item.ItemType == tid);
+            if (item == null || item.Count < count)
+            {
+                throw new BadHttpRequestException($"Insufficient item {tid}. Required: {count}, Available: {item?.Count ?? 0}", 400);
+            }
+        }
+    }
+
+    private static void DeductResources(User user, Dictionary<int, int> itemCosts, Dictionary<CurrencyType, long> currencyCosts, SkillLevelUpResult result)
+    {
+        foreach ((CurrencyType type, long value) in currencyCosts)
+        {
+            user.SubtractCurrency(type, value);
+            result.Currencies.Add(new NetUserCurrencyData
+            {
+                Type = (int)type,
+                Value = user.GetCurrencyVal(type)
             });
         }
 
-        NetUserCharacterDefaultData newChar = new()
+        foreach ((int tid, int count) in itemCosts)
+        {
+            DbItemData item = user.Items.First(item => item.ItemType == tid);
+            item.Count -= count;
+            result.Items.Add(NetUtils.ToNet(item));
+        }
+    }
+
+    private static NetUserCharacterDefaultData ToNetCharacter(CharacterModel character)
+    {
+        return new()
         {
             CostumeId = character.CostumeId,
             Csn = character.Csn,
@@ -59,34 +251,7 @@ public class SkillLevelUp : LobbyMessage
             DispatchTid = character.Tid,
             Skill1Lv = character.Skill1Lvl,
             Skill2Lv = character.Skill2Lvl,
-            UltiSkillLv = character.UltimateLevel,
+            UltiSkillLv = character.UltimateLevel
         };
-
-        if (req.Category == 1)
-        {
-            character.UltimateLevel++;
-            newChar.UltiSkillLv++;
-        }
-        else if (req.Category == 2)
-        {
-            character.Skill1Lvl++;
-            newChar.Skill1Lv++;
-        }
-        else if (req.Category == 3)
-        {
-            character.Skill2Lvl++;
-            newChar.Skill2Lv++;
-        }
-
-        if (character.UltimateLevel == 10 && character.Skill1Lvl == 10 && character.Skill2Lvl == 10)
-        {
-            user.AddTrigger(Trigger.CharacterSkillLevelMax, 1);
-        }
-
-        response.Character = newChar;
-
-        JsonDb.Save();
-
-        await WriteDataAsync(response);
     }
 }

--- a/EpinelPS/LobbyServer/Character/SkillLevelUpHelper.cs
+++ b/EpinelPS/LobbyServer/Character/SkillLevelUpHelper.cs
@@ -1,0 +1,217 @@
+using EpinelPS.Data;
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Character;
+
+internal class SkillLevelUpResult
+{
+    public NetUserCharacterDefaultData Character { get; set; } = new();
+    public List<NetUserItemData> Items { get; } = [];
+    public List<NetUserCurrencyData> Currencies { get; } = [];
+}
+
+internal static class SkillLevelUpHelper
+{
+    public static SkillLevelUpResult Upgrade(User user, long csn, CharacterSkillCategory category)
+    {
+        CharacterModel character = GetCharacter(user, csn);
+        return Upgrade(user, csn, category, GetSkillLevel(character, category) + 1);
+    }
+
+    public static SkillLevelUpResult Upgrade(User user, long csn, CharacterSkillCategory category, int targetLevel)
+    {
+        CharacterModel character = GetCharacter(user, csn);
+
+        if (category == CharacterSkillCategory.None)
+        {
+            throw new BadHttpRequestException("Skill category is required", 400);
+        }
+
+        int currentLevel = GetSkillLevel(character, category);
+        if (targetLevel <= currentLevel)
+        {
+            return new SkillLevelUpResult { Character = ToNetCharacter(character) };
+        }
+
+        if (targetLevel > 10)
+        {
+            throw new BadHttpRequestException($"Invalid target skill level {targetLevel}", 400);
+        }
+
+        int levelUpCount = targetLevel - currentLevel;
+        int baseSkillId = GetBaseSkillId(character, category);
+        Dictionary<int, int> itemCosts = [];
+        Dictionary<CurrencyType, long> currencyCosts = [];
+
+        for (int level = currentLevel; level < targetLevel; level++)
+        {
+            int skillId = baseSkillId + level - 1;
+            if (!GameData.Instance.skillInfoTable.TryGetValue(skillId, out SkillInfoRecord? skillRecord))
+            {
+                throw new BadHttpRequestException($"Skill info {skillId} not found", 400);
+            }
+
+            if (skillRecord.LevelUpCostId == 0)
+            {
+                continue;
+            }
+
+            if (!GameData.Instance.costTable.TryGetValue(skillRecord.LevelUpCostId, out CostRecord? costRecord))
+            {
+                throw new BadHttpRequestException($"Skill cost {skillRecord.LevelUpCostId} not found", 400);
+            }
+
+            AddCosts(costRecord, itemCosts, currencyCosts);
+        }
+
+        EnsureEnoughResources(user, itemCosts, currencyCosts);
+
+        SkillLevelUpResult result = new();
+        DeductResources(user, itemCosts, currencyCosts, result);
+
+        SetSkillLevel(character, category, targetLevel);
+        result.Character = ToNetCharacter(character);
+
+        user.AddTrigger(Trigger.CharacterSkillLevelUpCount, levelUpCount);
+        if (character.UltimateLevel == 10 && character.Skill1Lvl == 10 && character.Skill2Lvl == 10)
+        {
+            user.AddTrigger(Trigger.CharacterSkillLevelMax, 1);
+        }
+
+        return result;
+    }
+
+    private static CharacterModel GetCharacter(User user, long csn)
+    {
+        return user.Characters.FirstOrDefault(c => c.Csn == csn)
+            ?? throw new BadHttpRequestException($"Character with CSN {csn} not found", 404);
+    }
+
+    private static int GetBaseSkillId(CharacterModel character, CharacterSkillCategory category)
+    {
+        if (!GameData.Instance.CharacterTable.TryGetValue(character.Tid, out CharacterRecord? charRecord))
+        {
+            throw new BadHttpRequestException($"Character record {character.Tid} not found", 404);
+        }
+
+        return category switch
+        {
+            CharacterSkillCategory.Ultimate => charRecord.UltiSkillId,
+            CharacterSkillCategory.Skill1 => charRecord.Skill1Id,
+            CharacterSkillCategory.Skill2 => charRecord.Skill2Id,
+            _ => throw new BadHttpRequestException("Invalid skill category", 400)
+        };
+    }
+
+    private static int GetSkillLevel(CharacterModel character, CharacterSkillCategory category)
+    {
+        return category switch
+        {
+            CharacterSkillCategory.Ultimate => character.UltimateLevel,
+            CharacterSkillCategory.Skill1 => character.Skill1Lvl,
+            CharacterSkillCategory.Skill2 => character.Skill2Lvl,
+            _ => throw new BadHttpRequestException("Invalid skill category", 400)
+        };
+    }
+
+    private static void SetSkillLevel(CharacterModel character, CharacterSkillCategory category, int targetLevel)
+    {
+        switch (category)
+        {
+            case CharacterSkillCategory.Ultimate:
+                character.UltimateLevel = targetLevel;
+                break;
+            case CharacterSkillCategory.Skill1:
+                character.Skill1Lvl = targetLevel;
+                break;
+            case CharacterSkillCategory.Skill2:
+                character.Skill2Lvl = targetLevel;
+                break;
+            default:
+                throw new BadHttpRequestException("Invalid skill category", 400);
+        }
+    }
+
+    private static void AddCosts(CostRecord costRecord, Dictionary<int, int> itemCosts, Dictionary<CurrencyType, long> currencyCosts)
+    {
+        foreach (CostData cost in costRecord.Costs.Where(cost => cost.ItemType != RewardType.None && cost.ItemValue > 0))
+        {
+            if (cost.ItemType == RewardType.Currency)
+            {
+                CurrencyType type = (CurrencyType)cost.ItemId;
+                if (!currencyCosts.TryAdd(type, cost.ItemValue))
+                {
+                    currencyCosts[type] += cost.ItemValue;
+                }
+            }
+            else if (cost.ItemType == RewardType.Item)
+            {
+                if (!itemCosts.TryAdd(cost.ItemId, cost.ItemValue))
+                {
+                    itemCosts[cost.ItemId] += cost.ItemValue;
+                }
+            }
+            else
+            {
+                throw new BadHttpRequestException($"Unsupported skill level cost type {cost.ItemType}", 400);
+            }
+        }
+    }
+
+    private static void EnsureEnoughResources(User user, Dictionary<int, int> itemCosts, Dictionary<CurrencyType, long> currencyCosts)
+    {
+        foreach ((CurrencyType type, long value) in currencyCosts)
+        {
+            if (!user.CanSubtractCurrency(type, value))
+            {
+                throw new BadHttpRequestException($"Insufficient currency {type}. Required: {value}, Available: {user.GetCurrencyVal(type)}", 400);
+            }
+        }
+
+        foreach ((int tid, int count) in itemCosts)
+        {
+            DbItemData? item = user.Items.FirstOrDefault(item => item.ItemType == tid);
+            if (item == null || item.Count < count)
+            {
+                throw new BadHttpRequestException($"Insufficient item {tid}. Required: {count}, Available: {item?.Count ?? 0}", 400);
+            }
+        }
+    }
+
+    private static void DeductResources(User user, Dictionary<int, int> itemCosts, Dictionary<CurrencyType, long> currencyCosts, SkillLevelUpResult result)
+    {
+        foreach ((CurrencyType type, long value) in currencyCosts)
+        {
+            user.SubtractCurrency(type, value);
+            result.Currencies.Add(new NetUserCurrencyData
+            {
+                Type = (int)type,
+                Value = user.GetCurrencyVal(type)
+            });
+        }
+
+        foreach ((int tid, int count) in itemCosts)
+        {
+            DbItemData item = user.Items.First(item => item.ItemType == tid);
+            item.Count -= count;
+            result.Items.Add(NetUtils.ToNet(item));
+        }
+    }
+
+    private static NetUserCharacterDefaultData ToNetCharacter(CharacterModel character)
+    {
+        return new()
+        {
+            CostumeId = character.CostumeId,
+            Csn = character.Csn,
+            Lv = character.Level,
+            Grade = character.Grade,
+            Tid = character.Tid,
+            DispatchTid = character.Tid,
+            Skill1Lv = character.Skill1Lvl,
+            Skill2Lv = character.Skill2Lvl,
+            UltiSkillLv = character.UltimateLevel
+        };
+    }
+}

--- a/EpinelPS/LobbyServer/Character/SkillLevelUpV2.cs
+++ b/EpinelPS/LobbyServer/Character/SkillLevelUpV2.cs
@@ -1,18 +1,17 @@
-using EpinelPS.Data;
 using EpinelPS.Database;
 
 namespace EpinelPS.LobbyServer.Character;
 
-[GameRequest("/character/skill/levelup")]
-public class SkillLevelUp : LobbyMessage
+[GameRequest("/character/skill/levelupV2")]
+public class SkillLevelUpV2 : LobbyMessage
 {
     protected override async Task HandleAsync()
     {
-        ReqCharacterSkillLevelUp req = await ReadData<ReqCharacterSkillLevelUp>();
+        ReqCharacterSkillLevelUpV2 req = await ReadData<ReqCharacterSkillLevelUpV2>();
         User user = GetUser();
-        ResCharacterSkillLevelUp response = new();
+        ResCharacterSkillLevelUpV2 response = new();
 
-        SkillLevelUpResult result = SkillLevelUpHelper.Upgrade(user, req.Csn, (CharacterSkillCategory)req.Category);
+        SkillLevelUpResult result = SkillLevelUpHelper.Upgrade(user, req.Csn, req.SkillCategory, req.TargetLevel);
         response.Character = result.Character;
         response.Items.AddRange(result.Items);
         response.Currencies.AddRange(result.Currencies);

--- a/EpinelPS/Utils/NetUtils.cs
+++ b/EpinelPS/Utils/NetUtils.cs
@@ -244,44 +244,56 @@ public class NetUtils
         return CalcOutpostRewardAmount(value, ratio, boost, mins);
     }
 
+    private static long GetOutpostRewardAmount(User user, CurrencyType type, double mins, bool includeBoost, double ratio)
+    {
+        OutpostBattleRecord battleData = GameData.Instance.OutpostBattle[user.OutpostBattleLevel.Level];
+        double boost = 1.0;
+        if (includeBoost)
+            boost += CalculateBoostValueForOutpost(user, type);
+
+        int value = type switch
+        {
+            CurrencyType.CharacterExp2 => battleData.CharacterExp2,
+            CurrencyType.CharacterExp => battleData.CharacterExp1,
+            CurrencyType.Gold => battleData.Credit,
+            CurrencyType.UserExp => battleData.UserExp,
+            _ => 0
+        };
+
+        return CalcOutpostRewardAmount(value, ratio, boost, mins);
+    }
+
+    private static void AddOutpostRewardCurrency(User user, NetRewardData reward, CurrencyType type, TimeSpan duration, bool addToUser, double ratio)
+    {
+        long rewardValue = GetOutpostRewardAmount(user, type, duration.TotalMinutes, true, ratio);
+        long finalValue;
+
+        if (addToUser)
+        {
+            user.AddCurrency(type, rewardValue);
+            finalValue = user.GetCurrencyVal(type);
+        }
+        else
+        {
+            finalValue = user.Currency.TryGetValue(type, out long currentValue) ? currentValue + rewardValue : rewardValue;
+        }
+
+        reward.Currency.Add(new NetCurrencyData()
+        {
+            Type = (int)type,
+            Value = rewardValue,
+            FinalValue = finalValue
+        });
+    }
+
     public static NetRewardData GetOutpostReward(User user, TimeSpan duration, bool addToUser = false)
     {
-        //duration = TimeSpan.FromHours(1);
         NetRewardData result = new();
 
-        OutpostBattleRecord battleData = GameData.Instance.OutpostBattle[user.OutpostBattleLevel.Level];
-
-        result.Currency.Add(new NetCurrencyData()
-        {
-            Type = (int)CurrencyType.CharacterExp2,
-            FinalValue = 0,
-            Value = CalcOutpostRewardAmount(battleData.CharacterExp2, 1, 1, duration.TotalMinutes)
-        });
-        if (addToUser) user.AddCurrency(CurrencyType.CharacterExp2, result.Currency.Last().Value);
-
-        result.Currency.Add(new NetCurrencyData()
-        {
-            Type = (int)CurrencyType.CharacterExp,
-            FinalValue = 0,
-            Value = CalcOutpostRewardAmount(battleData.CharacterExp1, 3, 1, duration.TotalMinutes)
-        });
-        if (addToUser) user.AddCurrency(CurrencyType.CharacterExp, result.Currency.Last().Value);
-
-        result.Currency.Add(new NetCurrencyData()
-        {
-            Type = (int)CurrencyType.Gold,
-            FinalValue = 0,
-            Value = CalcOutpostRewardAmount(battleData.Credit, 3, 1, duration.TotalMinutes)
-        });
-        if (addToUser) user.AddCurrency(CurrencyType.Gold, result.Currency.Last().Value);
-
-        result.Currency.Add(new NetCurrencyData()
-        {
-            Type = (int)CurrencyType.UserExp,
-            FinalValue = 0,
-            Value = CalcOutpostRewardAmount(battleData.UserExp, 3, 1, duration.TotalMinutes)
-        });
-        if (addToUser) user.AddCurrency(CurrencyType.UserExp, result.Currency.Last().Value);
+        AddOutpostRewardCurrency(user, result, CurrencyType.CharacterExp2, duration, addToUser, 1);
+        AddOutpostRewardCurrency(user, result, CurrencyType.CharacterExp, duration, addToUser, 3);
+        AddOutpostRewardCurrency(user, result, CurrencyType.Gold, duration, addToUser, 3);
+        AddOutpostRewardCurrency(user, result, CurrencyType.UserExp, duration, addToUser, 3);
 
         return result;
     }


### PR DESCRIPTION
Title: Fix character skill upgrades and outpost reward currency updates

## Summary
This PR fixes two gameplay progression issues:

- Adds support for the current character skill upgrade flow, including `/character/skill/levelupV2`.
- Fixes outpost battle reward currency responses so claimed credits and other currencies return correct final balances and use outpost buffs.

## Details
### Character skill upgrades
- Keeps `/character/skill/levelup` working.
- Adds `/character/skill/levelupV2`.
- Supports target-level upgrades.
- Accumulates all intermediate level-up costs.
- Supports both item and currency costs.
- Validates resources before mutating user data.
- Returns updated character, item, and currency state.
- Adds `Trigger.CharacterSkillLevelUpCount` and preserves max-skill trigger behavior.

### Outpost rewards
- Removes hardcoded `FinalValue = 0` for outpost reward currencies.
- Returns the final balance after claim, or the projected final balance for preview.
- Uses the existing outpost buff calculation path.
- Keeps the existing reward ratios from the old claim path.

## Testing
- `dotnet build .\EpinelPS\EpinelPS.csproj`
- Local gameplay smoke test:
  - Character skill upgrade updates levels and resources.
  - Outpost reward/fast battle credit values update correctly.

## Notes
Build produced existing/non-blocking warnings in the local environment:

- `NU1900` when NuGet vulnerability data could not be fetched due local network sandboxing.
- Existing generated lowercase type warning for `missionvaluedata`.
- Existing nullable warnings in `Views/Admin/Events.cshtml`.
