### PR TITLE
Fix crashing when trying get side story reward which is empty

### DIFF
--- a/EpinelPS/Data/GameData.cs
+++ b/EpinelPS/Data/GameData.cs
@@ -725,7 +725,7 @@ public class GameData
     }
     public RewardRecord? GetRewardTableEntry(int rewardId)
     {
-        return RewardDataRecords[rewardId];
+        return RewardDataRecords.TryGetValue(rewardId, out RewardRecord? record) ? record : null;
     }
     /// <summary>
     /// Returns the level and its minimum value for XP value

--- a/EpinelPS/LobbyServer/Sidestory/ClearSideStoryStage.cs
+++ b/EpinelPS/LobbyServer/Sidestory/ClearSideStoryStage.cs
@@ -23,8 +23,6 @@ public class ClearSideStoryStage : LobbyMessage
                 RewardRecord? rewardData = GameData.Instance.GetRewardTableEntry(value.FirstClearReward);
                 if (rewardData != null)
                     response.Reward = RewardUtils.RegisterRewardsForUser(user, rewardData);
-                else
-                    throw new Exception("failed to find reward");
             }
 
             JsonDb.Save();


### PR DESCRIPTION
Some side story stages don't have rewards, so the response should be empty if no reward record is found.