### PR TITLE
Counsel system fix: dialog tracking, dynamic count, dedup, level cap

### DIFF
--- a/EpinelPS/LobbyServer/Character/Counsel/DoCounsel.cs
+++ b/EpinelPS/LobbyServer/Character/Counsel/DoCounsel.cs
@@ -25,10 +25,15 @@ public class DoCounsel : LobbyMessage
             int beforeLv = currentBondInfo.Lv;
             int beforeExp = currentBondInfo.Exp;
 
-            currentBondInfo.Exp += 100;
             currentBondInfo.CounseledCount++;
+            if (!currentBondInfo.CounselDialogCompleteIds.Contains(req.CounselTid))
+                currentBondInfo.CounselDialogCompleteIds.Add(req.CounselTid);
             currentBondInfo.CanCounselToday = true; // Always allow counseling
-            UpdateAttractiveLevel(currentBondInfo);
+            if (currentBondInfo.Lv < user.GetMaxAttractiveLevel(req.NameCode))
+            {
+                currentBondInfo.Exp += 100;
+                UpdateAttractiveLevel(currentBondInfo);
+            }
 
             response.Attractive = currentBondInfo;
             response.Exp = new NetIncreaseExpData
@@ -52,6 +57,7 @@ public class DoCounsel : LobbyMessage
                 CanCounselToday = true,
                 Lv = 1
             };
+            data.CounselDialogCompleteIds.Add(req.CounselTid);
             UpdateAttractiveLevel(data);
             user.BondInfo.Add(data);
             response.Attractive = data;

--- a/EpinelPS/LobbyServer/Character/Counsel/ListAnswered.cs
+++ b/EpinelPS/LobbyServer/Character/Counsel/ListAnswered.cs
@@ -1,0 +1,21 @@
+namespace EpinelPS.LobbyServer.Character.Counsel;
+
+[GameRequest("/character/counsel/answer/list")]
+public class ListAnswered : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqListAnsweredAttractiveCounsel req = await ReadData<ReqListAnsweredAttractiveCounsel>();
+        User user = GetUser();
+
+        ResListAnsweredAttractiveCounsel response = new();
+
+        NetUserAttractiveData? bondInfo = user.BondInfo.FirstOrDefault(x => x.NameCode == req.NameCode);
+        if (bondInfo != null)
+        {
+            response.CorrectlyAnsweredAttractiveCounselTableIdList.AddRange(bondInfo.CounselDialogCompleteIds);
+        }
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Character/Counsel/Present.cs
+++ b/EpinelPS/LobbyServer/Character/Counsel/Present.cs
@@ -67,8 +67,11 @@ public class Present : LobbyMessage
         int beforeLv = bondInfo.Lv;
         int beforeExp = bondInfo.Exp;
 
-        bondInfo.Exp += totalExpGained;
-        UpdateAttractiveLevel(bondInfo);
+        if (bondInfo.Lv < user.GetMaxAttractiveLevel(req.NameCode))
+        {
+            bondInfo.Exp += totalExpGained;
+            UpdateAttractiveLevel(bondInfo);
+        }
 
         response.Attractive = bondInfo;
         response.Exp = new NetIncreaseExpData

--- a/EpinelPS/LobbyServer/Character/Counsel/QuickCounsel.cs
+++ b/EpinelPS/LobbyServer/Character/Counsel/QuickCounsel.cs
@@ -25,10 +25,13 @@ public class QuickCounsel : LobbyMessage
             int beforeLv = bondInfo.Lv;
             int beforeExp = bondInfo.Exp;
 
-            bondInfo.Exp += 100;
             bondInfo.CounseledCount++;
             bondInfo.CanCounselToday = true; // Always allow counseling
-            UpdateAttractiveLevel(bondInfo);
+            if (bondInfo.Lv < user.GetMaxAttractiveLevel(req.NameCode))
+            {
+                bondInfo.Exp += 100;
+                UpdateAttractiveLevel(bondInfo);
+            }
 
             response.Attractive = bondInfo;
             response.Exp = new NetIncreaseExpData

--- a/EpinelPS/LobbyServer/Character/GetCharacterAttractiveList.cs
+++ b/EpinelPS/LobbyServer/Character/GetCharacterAttractiveList.cs
@@ -10,7 +10,7 @@ public class GetCharacterAttractiveList : LobbyMessage
 
         ResGetAttractiveList response = new()
         {
-            CounselAvailableCount = 3 // TODO
+            CounselAvailableCount = user.ResetableData.DailyCounselCount.GetValueOrDefault(1, 3)
         };
 
         foreach (NetUserAttractiveData item in user.BondInfo)

--- a/EpinelPS/LobbyServer/LobbyUser/SetScenarioCompleted.cs
+++ b/EpinelPS/LobbyServer/LobbyUser/SetScenarioCompleted.cs
@@ -17,7 +17,8 @@ public class SetScenarioCompleted : LobbyMessage
             Reward = new NetRewardData()
         };
 
-        user.CompletedScenarios.Add(req.ScenarioId);
+        if (!user.CompletedScenarios.Contains(req.ScenarioId))
+            user.CompletedScenarios.Add(req.ScenarioId);
 
         if (GameData.Instance.ScenarioRewards.TryGetValue(req.ScenarioId, out ScenarioRewardsRecord? record))
         {

--- a/EpinelPS/Models/UserModel.cs
+++ b/EpinelPS/Models/UserModel.cs
@@ -421,6 +421,29 @@ public class User
         }
     }
 
+    internal int GetMaxAttractiveLevel(int nameCode)
+    {
+        int maxStars = 0;
+        foreach (var c in Characters)
+        {
+            if (GameData.Instance.CharacterTable.TryGetValue(c.Tid, out var cr) && cr.NameCode == nameCode)
+            {
+                int stars = Math.Min(c.Grade, 3);
+                if (stars > maxStars) maxStars = stars;
+            }
+        }
+        int cap = 30;
+        foreach (var kvp in GameData.Instance.CharacterTable.Values)
+        {
+            if (kvp.NameCode == nameCode && kvp.Corporation == CorporationType.PILGRIM)
+            {
+                cap = 40;
+                break;
+            }
+        }
+        return Math.Min(10 + maxStars * 10, cap);
+    }
+
     /// <summary>
     /// Removes the specified amount of items by their ID. Returns the amount of items removed.
     /// </summary>


### PR DESCRIPTION
## Fix
Counsel system fixes: dialog collection tracking, dynamic counsel count, dedup guard, bond level cap.

## Changes
- New `ListAnswered` endpoint — returns completed counsel dialog IDs
- `DoCounsel` — records dialog IDs after each counsel session (both branches)
- `GetCharacterAttractiveList` — counsel count from Infracore instead of hardcoded 3
- `SetScenarioCompleted` — dedup guard prevents duplicate scenario entries
- `UserModel` — bond level cap: PILGRIM 40 / others 30 / +10 per star
- `QuickCounsel` / `Present` — no EXP gain at max level

## Tested
- Counsel collection unlocks correctly
- Counsel count scales with Infracore upgrades
- Same scenario doesn't create duplicates in db
- Bond level stops at cap