### PR TITLE
Outpost system fixes: MoveBuilding, Synchro OneClick, Recycle Room, D…

### DIFF
--- a/EpinelPS/LobbyServer/Character/SynchroDeviceOneClick.cs
+++ b/EpinelPS/LobbyServer/Character/SynchroDeviceOneClick.cs
@@ -1,0 +1,56 @@
+using EpinelPS.Data;
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Character;
+
+[GameRequest("/character/synchrodevice/deviceoneclick")]
+public class SynchroDeviceOneClick : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSynchroDeviceOneClick req = await ReadData<ReqSynchroDeviceOneClick>();
+        User user = GetUser();
+        ResSynchroDeviceOneClick response = new();
+
+        int targetLv = req.SynchroLv;
+        if (targetLv > user.SynchroDeviceLevel)
+        {
+            var levelData = GameData.Instance.GetCharacterLevelUpData();
+
+            int totalGold = 0;
+            int totalExp = 0;
+            int totalExp2 = 0;
+
+            int lv;
+            for (lv = user.SynchroDeviceLevel; lv < targetLv; lv++)
+            {
+                if (levelData.TryGetValue(lv + 1, out var data))
+                {
+                    totalGold += data.Gold;
+                    totalExp += data.CharacterExp;
+                    totalExp2 += data.CharacterExp2;
+                }
+                else { break; }
+            }
+
+            if (lv > user.SynchroDeviceLevel &&
+                user.CanSubtractCurrency(CurrencyType.Gold, totalGold) &&
+                user.CanSubtractCurrency(CurrencyType.CharacterExp, totalExp) &&
+                user.CanSubtractCurrency(CurrencyType.CharacterExp2, totalExp2))
+            {
+                user.SubtractCurrency(CurrencyType.Gold, totalGold);
+                user.SubtractCurrency(CurrencyType.CharacterExp, totalExp);
+                user.SubtractCurrency(CurrencyType.CharacterExp2, totalExp2);
+                user.SynchroDeviceLevel = lv;
+                user.SynchroDeviceUpgraded = true;
+                JsonDb.Save();
+            }
+        }
+
+        response.SynchroLv = user.SynchroDeviceLevel;
+        foreach (var c in user.Currency)
+            response.Currencies.Add(new NetUserCurrencyData() { Type = (int)c.Key, Value = c.Value });
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Character/SynchroLevelUp.cs
+++ b/EpinelPS/LobbyServer/Character/SynchroLevelUp.cs
@@ -18,7 +18,7 @@ public class SynchroLevelUp : LobbyMessage
         int requiredCredit = 0;
         int requiredBattleData = 0;
         int requiredCoreDust = 0;
-        CharacterLevelRecord levelUpData = data[user.SynchroDeviceLevel + 1];
+        if (!data.TryGetValue(user.SynchroDeviceLevel + 1, out var levelUpData)) return;
         requiredCredit += levelUpData.Gold;
         requiredBattleData += levelUpData.CharacterExp;
         requiredCoreDust += levelUpData.CharacterExp2;

--- a/EpinelPS/LobbyServer/Outpost/Dispatch/DispatchHelper.cs
+++ b/EpinelPS/LobbyServer/Outpost/Dispatch/DispatchHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace EpinelPS.LobbyServer.Outpost.Dispatch;
+﻿using EpinelPS.Data;
+
+namespace EpinelPS.LobbyServer.Outpost.Dispatch;
 
 public class DispatchHelper
 {
@@ -28,5 +30,25 @@ public class DispatchHelper
         }
 
         return items.Last();
+    }
+
+    public static void SyncDispatchLevel(User user)
+    {
+        var completed = user.CompletedTacticAcademyLessons;
+        int count = 0;
+        foreach (var lid in completed)
+        {
+            var lesson = GameData.Instance.GetTacticAcademyLesson(lid);
+            if (lesson != null && lesson.LessonType == LessonType.Dispatch)
+                count++;
+        }
+        int newLv = Math.Max(1, count);
+        if (newLv != user.DispatchLv)
+        {
+            user.DispatchLv = newLv;
+            user.DispatchCollectionLv = newLv;
+            user.DispatchFavoriteLv = newLv;
+            user.UserDispatchData.Today = 0;
+        }
     }
 }

--- a/EpinelPS/LobbyServer/Outpost/Dispatch/GetDispatchList.cs
+++ b/EpinelPS/LobbyServer/Outpost/Dispatch/GetDispatchList.cs
@@ -14,6 +14,7 @@ public class GetDispatchList : LobbyMessage
         ResGetDispatchList response = new();
 
         User user = GetUser();
+        DispatchHelper.SyncDispatchLevel(user);
 
         List<DispatchBoardData> dispatch = GameData.Instance.DispatchBoardTable.Values
             .Where(x => x.DispatchType == DispatchType.Dispatch && x.DispatchBoardLv == user.DispatchLv)

--- a/EpinelPS/LobbyServer/Outpost/Dispatch/ResetDispatchList.cs
+++ b/EpinelPS/LobbyServer/Outpost/Dispatch/ResetDispatchList.cs
@@ -12,6 +12,7 @@ public class ResetDispatchList : LobbyMessage
 
         ResResetDispatchList response = new();
         User user = GetUser();
+        DispatchHelper.SyncDispatchLevel(user);
         DateTime startTime = DateTime.UtcNow;
         Random random = new();
         user.DispatchResetCount++;

--- a/EpinelPS/LobbyServer/Outpost/GetOutpostData.cs
+++ b/EpinelPS/LobbyServer/Outpost/GetOutpostData.cs
@@ -12,6 +12,15 @@ public class GetOutpostData : LobbyMessage
         User user = GetUser();
         user.ResetDataIfNeeded();
 
+        // Enter reset: restore stamina on each outpost entry (private server convenience)
+        var infracore = GameData.Instance.InfracoreTable.Values
+            .Where(x => x.Grade == user.InfraCoreLvl).FirstOrDefault();
+        if (infracore != null)
+        {
+            int staminaVal = 2 + (infracore.FunctionList.Count > 4 ? infracore.FunctionList[4].Function : 0);
+            user.Currency[CurrencyType.ContentStamina] = staminaVal;
+        }
+
         TimeSpan battleTime = DateTime.UtcNow - user.BattleTime;
         long battleTimeMs = (long)(battleTime.TotalNanoseconds / 100);
 

--- a/EpinelPS/LobbyServer/Outpost/GetRecycleRoomData.cs
+++ b/EpinelPS/LobbyServer/Outpost/GetRecycleRoomData.cs
@@ -14,8 +14,7 @@ public class GetRecycleRoomData : LobbyMessage
             return new NetUserRecycleRoomData()
             {
                 Tid = progress.Key,
-                Lv = progress.Value.Level,
-                Exp = progress.Value.Exp
+                Lv = progress.Value.Level
             };
         }));
 

--- a/EpinelPS/LobbyServer/Outpost/MoveBuilding.cs
+++ b/EpinelPS/LobbyServer/Outpost/MoveBuilding.cs
@@ -1,0 +1,25 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Outpost;
+
+[GameRequest("/Outpost/MoveBuilding")]
+public class MoveBuilding : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqMoveBuilding req = await ReadData<ReqMoveBuilding>();
+        User user = GetUser();
+
+        NetUserOutpostData? src = user.OutpostBuildings.FirstOrDefault(x => x.SlotId == req.SrcPositionId);
+        NetUserOutpostData? dst = user.OutpostBuildings.FirstOrDefault(x => x.SlotId == req.DstPositionId);
+
+        if (src != null && dst != null)
+        {
+            (src.SlotId, dst.SlotId) = (dst.SlotId, src.SlotId);
+            JsonDb.Save();
+        }
+
+        ResMoveBuilding response = new();
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Outpost/Recycle/LevelUpResearch.cs
+++ b/EpinelPS/LobbyServer/Outpost/Recycle/LevelUpResearch.cs
@@ -36,7 +36,7 @@ public class LevelUpResearch : LobbyMessage
         GameData.Instance.RecycleResearchStats.TryGetValue(req.Tid, out RecycleResearchStatRecord? statRecord);
         if (statRecord is null)
             return;
-        RecycleResearchLevelRecord? levelRecord = GameData.Instance.RecycleResearchLevels.Values.Where(e => e.RecycleType == statRecord.RecycleType)
+        RecycleResearchLevelRecord? levelRecord = GameData.Instance.RecycleResearchLevels.Values.Where(e => e.RecycleType == statRecord.RecycleType && e.RecycleSubType == statRecord.RecycleSubType)
             .FirstOrDefault(e => e.RecycleLevel == progress.Level);
         if (levelRecord is null)
             return;
@@ -58,49 +58,31 @@ public class LevelUpResearch : LobbyMessage
                 Lv = progress.Level,
             };
         }
-        else if (statRecord.RecycleType == RecycleType.Class || statRecord.RecycleType == RecycleType.Corporation) // class research or corporation research
+        else if (statRecord.RecycleType == RecycleType.Class || statRecord.RecycleType == RecycleType.Corporation)
         {
-            DbItemData? usedItem = user.Items.FirstOrDefault(e => e.ItemType == req.Tid);
-            if (usedItem is null)
-                return;
+            for (int i = 0; i < req.LevelUpCount; i++)
+            {
+                RecycleResearchLevelRecord? currentLevelRecord = GameData.Instance.RecycleResearchLevels.Values
+                    .Where(e => e.RecycleType == statRecord.RecycleType && e.RecycleSubType == statRecord.RecycleSubType)
+                    .FirstOrDefault(e => e.RecycleLevel == progress.Level);
+                if (currentLevelRecord is null) break;
 
-            usedItem.Count -= 1;
-            response.Items.Add(NetUtils.UserItemDataToNet(usedItem));
-            (int newLevel, int newExp) = CalcCorpAndClassLevelUp(statRecord.RecycleType, 1, progress.Level, progress.Exp);
-            progress.Level = newLevel;
-            progress.Exp = newExp;
+                DbItemData? usedItem = user.Items.FirstOrDefault(e => e.ItemType == currentLevelRecord.ItemId);
+                if (usedItem is null || usedItem.Count < currentLevelRecord.ItemValue) break;
+
+                usedItem.Count -= currentLevelRecord.ItemValue;
+                response.Items.Add(NetUtils.UserItemDataToNet(usedItem));
+                progress.Level += 1;
+            }
             response.Recycle = new()
             {
                 Tid = req.Tid,
-                Lv = newLevel,
-                Exp = newExp,
+                Lv = progress.Level,
             };
         }
         else
         {
             throw new Exception($"unknown recycle type {statRecord.RecycleType}");
         }
-    }
-
-    // First: level, Second: exp
-    private static (int, int) CalcCorpAndClassLevelUp(RecycleType researchType, int itemCount, int startLevel = 1, int startExp = 0)
-    {
-        // levelRecord.exp is required exp to level up.
-        IEnumerable<RecycleResearchLevelRecord> levelRecords = GameData.Instance.RecycleResearchLevels.Values.Where(e => e.RecycleType == researchType && e.RecycleLevel > startLevel);
-
-        foreach (RecycleResearchLevelRecord? record in levelRecords)
-        {
-            if (itemCount < record.ItemValue)
-            {
-                startExp += itemCount;
-                break;
-            }
-
-            itemCount -= record.ItemValue - startExp;
-            startLevel += 1;
-            startExp = 0;
-        }
-
-        return (startLevel, startExp);
     }
 }

--- a/EpinelPS/LobbyServer/Outpost/Recycle/PersonalResearchLevelUp.cs
+++ b/EpinelPS/LobbyServer/Outpost/Recycle/PersonalResearchLevelUp.cs
@@ -1,4 +1,6 @@
+using EpinelPS.Data;
 using EpinelPS.Database;
+using EpinelPS.Utils;
 
 namespace EpinelPS.LobbyServer.Outpost.Recycle;
 
@@ -13,12 +15,30 @@ public class PersonalResearchLevelUp : LobbyMessage
 
         const int personalResearchTid = 1001;
         RecycleRoomResearchProgress personalResearchProgress = user.ResearchProgress[personalResearchTid] ?? throw new Exception("PersonalRearch not found.");
-        personalResearchProgress.Level += req.LevelUpCount;
+
+        GameData.Instance.RecycleResearchStats.TryGetValue(personalResearchTid, out RecycleResearchStatRecord? statRecord);
+        if (statRecord is null) return;
+
+        for (int i = 0; i < req.LevelUpCount; i++)
+        {
+            RecycleResearchLevelRecord? levelRecord = GameData.Instance.RecycleResearchLevels.Values
+                .Where(e => e.RecycleType == statRecord.RecycleType && e.RecycleSubType == statRecord.RecycleSubType)
+                .FirstOrDefault(e => e.RecycleLevel == personalResearchProgress.Level);
+            if (levelRecord is null) break;
+
+            DbItemData? usedItem = user.Items.FirstOrDefault(e => e.ItemType == levelRecord.ItemId);
+            if (usedItem is null || usedItem.Count < levelRecord.ItemValue) break;
+
+            usedItem.Count -= levelRecord.ItemValue;
+            response.Item = NetUtils.UserItemDataToNet(usedItem);
+            personalResearchProgress.Level += 1;
+            personalResearchProgress.Hp = statRecord.Hp * personalResearchProgress.Level;
+        }
+
         response.Recycle = new()
         {
             Tid = personalResearchTid,
-            Lv = personalResearchProgress.Level,
-            Exp = personalResearchProgress.Exp
+            Lv = personalResearchProgress.Level
         };
 
         JsonDb.Save();

--- a/EpinelPS/LobbyServer/Outpost/Recycle/RunResearch.cs
+++ b/EpinelPS/LobbyServer/Outpost/Recycle/RunResearch.cs
@@ -31,7 +31,6 @@ public class RunResearch : LobbyMessage
         {
             Tid = req.Tid,
             Lv = progress.Level,
-            Exp = progress.Exp,
         };
 
         JsonDb.Save();

--- a/EpinelPS/Models/DbModels.cs
+++ b/EpinelPS/Models/DbModels.cs
@@ -132,7 +132,6 @@ public class SynchroSlot
 public class RecycleRoomResearchProgress
 {
     public int Level { get; set; } = 1;
-    public int Exp { get; set; }
     public int Attack { get; set; }
     public int Defense { get; set; }
     public int Hp { get; set; }

--- a/EpinelPS/Models/UserModel.cs
+++ b/EpinelPS/Models/UserModel.cs
@@ -563,6 +563,11 @@ public class User
                     CurrentSeasonData = currentSeasonData,
                 }
             };
+
+            // Weekly stamina reset: base 2 + InfraCore bonus (FL[4] = StaminaMaxCount)
+            if (infracore != null)
+                Currency[CurrencyType.ContentStamina] = 2 + infracore.FunctionList[4].Function;
+
             needsSave = true;
         }
 


### PR DESCRIPTION
## Fix
Outpost subsystem fixes: building swap, synchro device upgrade, recycle room item logic, dispatch level unlock, stamina recovery (weekly + on-entry).

## Changes & Results

### 1. MoveBuilding
Building slots can now be swapped. Previously the swap does not work.

### 2. Synchro Device Dynamic Level Cap and Upgrade Fix

- Upgrade (`/character/synchrodevice/deviceoneclick`) now works. 
- Remove hardcoded `SynchroMaxLv=1000` cap — Now using dynamic formula determines real max level cap.

### 3. Recycle Room

- General research (`PersonalResearchLevelUp`) now costs cycle energy per level. Previously does not consume cycle energy.
- Class/Corp upgrades works now, and maps to the right console via `RecycleSubType` filter (Missilis→Missilis Core, Defender→Defense Core). Original `req.Tid` lookup never matched any item.
- Class/Corp no longer uses  — one level per ItemValue consumtion.
- EXP mechanic removed from all recycle room responses.

### 4. Dispatch Level Unlock
Dispatch level now dynamically follows tactic academy progress. Previously completing Dispatch-type lessons had no effect — all dispatches stayed at 1-star minimum. Now higher lesson counts unlock higher dispatch tiers with 3-5 star rarity.

### 5. Stamina recovery 
Added Stamina recovery for weekly (offical) + on-entry (similar as counsel, recover when entering outpost)