### PR TITLE
Fix: attraction favorite flag, bond lv cap, dynamic SynchroMaxLv, Synchro oneclick

### DIFF
--- a/EpinelPS/LobbyServer/Character/GetSynchrodevice.cs
+++ b/EpinelPS/LobbyServer/Character/GetSynchrodevice.cs
@@ -39,12 +39,6 @@ public class GetSynchrodevice : LobbyMessage
             response.Synchro.Slots.Add(new NetSynchroSlot() { Slot = item.Slot, AvailableRegisterAt = 1, Csn = item.CharacterSerialNumber });
         }
 
-        // Official formula for Maximum Synchro Level:
-        //   Highest Nikke level + (Nikkes owned) + (Total Limit Breaks × 1.334)
-        // In EpinelPS a character's Grade encodes: 0-3 = star rank (these ARE
-        // the limit breaks), 4-10 = core/overload tiers (do NOT count). So a
-        // character's limit breaks = min(Grade, 3): R stays 0★ (0), SR caps at
-        // 2★ (2), SSR caps at 3★ (3); core breaks beyond 3★ are excluded.
         int highestLevel = user.Characters.Count > 0 ? user.Characters.Max(c => c.Level) : 0;
         int ownedCount = user.Characters.Count;
         int totalLimitBreaks = user.Characters.Sum(c => Math.Min(c.Grade, 3));

--- a/EpinelPS/LobbyServer/Character/GetSynchrodevice.cs
+++ b/EpinelPS/LobbyServer/Character/GetSynchrodevice.cs
@@ -1,4 +1,6 @@
-﻿namespace EpinelPS.LobbyServer.Character;
+﻿using EpinelPS.Data;
+
+namespace EpinelPS.LobbyServer.Character;
 
 [GameRequest("/character/synchrodevice/get")]
 public class GetSynchrodevice : LobbyMessage
@@ -37,7 +39,16 @@ public class GetSynchrodevice : LobbyMessage
             response.Synchro.Slots.Add(new NetSynchroSlot() { Slot = item.Slot, AvailableRegisterAt = 1, Csn = item.CharacterSerialNumber });
         }
 
-        response.Synchro.SynchroMaxLv = 1000;
+        // Official formula for Maximum Synchro Level:
+        //   Highest Nikke level + (Nikkes owned) + (Total Limit Breaks × 1.334)
+        // In EpinelPS a character's Grade encodes: 0-3 = star rank (these ARE
+        // the limit breaks), 4-10 = core/overload tiers (do NOT count). So a
+        // character's limit breaks = min(Grade, 3): R stays 0★ (0), SR caps at
+        // 2★ (2), SSR caps at 3★ (3); core breaks beyond 3★ are excluded.
+        int highestLevel = user.Characters.Count > 0 ? user.Characters.Max(c => c.Level) : 0;
+        int ownedCount = user.Characters.Count;
+        int totalLimitBreaks = user.Characters.Sum(c => Math.Min(c.Grade, 3));
+        response.Synchro.SynchroMaxLv = (int)(highestLevel + ownedCount + totalLimitBreaks * 1.334);
         response.Synchro.SynchroLv = user.GetSynchroLevel();
         response.Synchro.IsChanged = user.SynchroDeviceUpgraded;
 

--- a/EpinelPS/LobbyServer/Character/SetAttractiveFavorites.cs
+++ b/EpinelPS/LobbyServer/Character/SetAttractiveFavorites.cs
@@ -1,0 +1,22 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Character;
+
+[GameRequest("/character/attractive/setfavorites")]
+public class SetAttractiveFavorites : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSetAttractiveFavorites req = await ReadData<ReqSetAttractiveFavorites>();
+        User user = GetUser();
+
+        NetUserAttractiveData? bond = user.BondInfo.FirstOrDefault(x => x.NameCode == req.NameCode);
+        if (bond != null)
+        {
+            bond.IsFavorites = req.IsFavorites;
+            JsonDb.Save();
+        }
+
+        await WriteDataAsync(new ResSetAttractiveFavorites());
+    }
+}

--- a/EpinelPS/LobbyServer/Character/SynchroOneClick.cs
+++ b/EpinelPS/LobbyServer/Character/SynchroOneClick.cs
@@ -1,0 +1,79 @@
+using EpinelPS.Data;
+using EpinelPS.Database;
+using EpinelPS.Utils;
+using System.Linq;
+
+namespace EpinelPS.LobbyServer.Character;
+
+[GameRequest("/character/synchrodevice/oneclick")]
+public class SynchroOneClick : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSynchroOneClick req = await ReadData<ReqSynchroOneClick>();
+        User user = GetUser();
+        ResSynchroOneClick response = new();
+        Dictionary<int, CharacterLevelRecord> data = GameData.Instance.GetCharacterLevelUpData();
+        int maxLv = data.Keys.Count > 0 ? data.Keys.Max() : 0;
+
+        foreach (NetSynchroCharacter sc in req.Chars)
+        {
+            CharacterModel? character = user.Characters.FirstOrDefault(c => c.Csn == sc.Csn);
+            if (character == null) continue;
+
+            int targetLv = sc.Lv;
+            if (targetLv > maxLv) targetLv = maxLv;
+            if (targetLv <= character.Level) continue;
+
+            int requiredCredit = 0;
+            int requiredBattleData = 0;
+            int requiredCoreDust = 0;
+            bool valid = true;
+            for (int i = character.Level; i < targetLv; i++)
+            {
+                if (!data.TryGetValue(i, out var levelUpData)) { valid = false; break; }
+                requiredCredit += levelUpData.Gold;
+                requiredBattleData += levelUpData.CharacterExp;
+                requiredCoreDust += levelUpData.CharacterExp2;
+            }
+            if (!valid) continue;
+
+            if (user.CanSubtractCurrency(CurrencyType.Gold, requiredCredit) &&
+                user.CanSubtractCurrency(CurrencyType.CharacterExp, requiredBattleData) &&
+                user.CanSubtractCurrency(CurrencyType.CharacterExp2, requiredCoreDust))
+            {
+                user.SubtractCurrency(CurrencyType.Gold, requiredCredit);
+                user.SubtractCurrency(CurrencyType.CharacterExp, requiredBattleData);
+                user.SubtractCurrency(CurrencyType.CharacterExp2, requiredCoreDust);
+                character.Level = targetLv;
+            }
+            else
+            {
+                continue;
+            }
+
+            response.Characters.Add(new NetUserCharacterDefaultData()
+            {
+                Csn = character.Csn,
+                Tid = character.Tid,
+                Lv = character.Level,
+                Grade = character.Grade,
+                CostumeId = character.CostumeId,
+                UltiSkillLv = character.UltimateLevel,
+                Skill1Lv = character.Skill1Lvl,
+                Skill2Lv = character.Skill2Lvl,
+            });
+        }
+
+        response.SynchroLv = user.GetSynchroLevel();
+        foreach (CharacterModel c in user.Characters.OrderByDescending(x => x.Level).Take(5))
+            response.SynchroCharacters.Add(c.Csn);
+
+        foreach (KeyValuePair<CurrencyType, long> currency in user.Currency)
+            response.Currencies.Add(new NetUserCurrencyData() { Type = (int)currency.Key, Value = currency.Value });
+
+        user.AddTrigger(Trigger.CharacterLevelUpCount, response.Characters.Count);
+        JsonDb.Save();
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Character/SynchroRegisterOneClick.cs
+++ b/EpinelPS/LobbyServer/Character/SynchroRegisterOneClick.cs
@@ -1,0 +1,58 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Character;
+
+[GameRequest("/character/synchrodevice/registoneclick")]
+public class SynchroRegisterOneClick : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSynchroRegisterOneClick req = await ReadData<ReqSynchroRegisterOneClick>();
+        User user = GetUser();
+        ResSynchroRegisterOneClick response = new();
+
+        foreach (NetOneClickSlot oneClickSlot in req.Slots)
+        {
+            foreach (SynchroSlot slot in user.SynchroSlots)
+            {
+                if (slot.Slot == oneClickSlot.Slot)
+                {
+                    if (slot.CharacterSerialNumber == 0)
+                    {
+                        slot.CharacterSerialNumber = oneClickSlot.Csn;
+                    }
+                    break;
+                }
+            }
+        }
+
+        JsonDb.Save();
+
+        foreach (SynchroSlot slot in user.SynchroSlots)
+        {
+            response.Slots.Add(new NetSynchroSlot() { Slot = slot.Slot, AvailableRegisterAt = 1, Csn = slot.CharacterSerialNumber });
+        }
+
+        foreach (SynchroSlot slot in user.SynchroSlots)
+        {
+            if (slot.CharacterSerialNumber == 0) continue;
+            CharacterModel? character = user.GetCharacterBySerialNumber(slot.CharacterSerialNumber);
+            if (character == null) continue;
+            response.Characters.Add(new NetUserCharacterDefaultData()
+            {
+                Csn = character.Csn,
+                CostumeId = character.CostumeId,
+                Grade = character.Grade,
+                Lv = user.GetSynchroLevel(),
+                Skill1Lv = character.Skill1Lvl,
+                Skill2Lv = character.Skill2Lvl,
+                Tid = character.Tid,
+                UltiSkillLv = character.UltimateLevel
+            });
+        }
+
+        response.IsSynchro = true;
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/Models/UserModel.cs
+++ b/EpinelPS/Models/UserModel.cs
@@ -442,16 +442,16 @@ public class User
                 if (stars > maxStars) maxStars = stars;
             }
         }
-        int cap = 30;
+        int cap = 10 + Math.Min(maxStars, 2) * 10;
         foreach (var kvp in GameData.Instance.CharacterTable.Values)
         {
-            if (kvp.NameCode == nameCode && kvp.Corporation == CorporationType.PILGRIM)
+            if (kvp.NameCode == nameCode && kvp.Corporation == CorporationType.PILGRIM && maxStars >= 3)
             {
                 cap = 40;
                 break;
             }
         }
-        return Math.Min(10 + maxStars * 10, cap);
+        return cap;
     }
 
     /// <summary>


### PR DESCRIPTION
## Fix

### Add Attraction favorites handler
favorite flag on the character's bond entry is now available.

### Attractive (bond) level cap
PR #116 fixes the bond lv cap (10 at 0★, 20 at 1★, 30 at 2★）. PILGRIM characters raise cap to 40 at 3★ was not achieved, now fixed.

### Dynamic SynchroMaxLv 
Remove hardcoded SynchroMaxLv=1000 cap — now computed dynamically on the server using the official formula:
**Maximum Synchro Level = Highest Nikke level + Nikkes owned + (Total Limit Breaks × 1.334)**

### Add registoneclick / oneclick handler
Fix batch level-up of characters in synchro before unlock.
Fix auto placement function.