### PR TITLE
fix: prevent subquest messenger reward from being granted twice

### DIFF
--- a/EpinelPS/LobbyServer/Messenger/FinishSubquest.cs
+++ b/EpinelPS/LobbyServer/Messenger/FinishSubquest.cs
@@ -22,6 +22,12 @@ public class FinishSubquest : LobbyMessage
         user.SetSubQuest(req.SubQuestId, true);
 
         NetMessage conversationRecordUser = user.MessengerData.Where(x => x.MessageId == req.MessageId).First();
+        if (conversationRecordUser.State == 2)
+        {
+            // already claimed, don't grant the reward again
+            await WriteDataAsync(response);
+            return;
+        }
         conversationRecordUser.State = 2; // mark as claimed
 
         response.Reward = RewardUtils.RegisterRewardsForUser(user, rewardRecord);

--- a/EpinelPS/LobbyServer/Messenger/ProceedMsg.cs
+++ b/EpinelPS/LobbyServer/Messenger/ProceedMsg.cs
@@ -16,12 +16,10 @@ public class ProceedMsg : LobbyMessage
 
         KeyValuePair<string, MessengerDialogRecord> msgToSave = GameData.Instance.Messages.Where(x => x.Key == req.MessageId).First();
 
+        // NOTE: reward messages (MessageType Reward) are all subquest completion
+        // messages, their reward is granted by /messenger/finsubquest when the
+        // user presses the claim button. Do not grant anything here.
         response.Message = user.CreateMessage(msgToSave.Value.ConversationId, req.MessageId);
-
-        if (msgToSave.Value.RewardId != 0)
-        {
-            Logging.WriteLine("TODO reward for messenger. Reward ID: " + msgToSave.Value.RewardId + " Message ID: " + req.MessageId, LogType.Warning);
-        }
 
         JsonDb.Save();
 


### PR DESCRIPTION
## Problem

`/messenger/finsubquest` grants the subquest completion reward every time it is called, without checking whether the reward message was already claimed (`State == 2`). If the client re-sends the claim request (e.g. a second tap on the claim button in the BlaBla chat), the reward is granted again.

Verified on a live server: after claiming subquest 1061's reward, a repeated `finsubquest` call for the same message granted item 7050003 ×2 a second time (stack went 2 → 4).

## Fix

Return early with an empty response when the message is already marked as claimed.

This PR also removes the misleading `TODO reward for messenger` warning in `ProceedMsg`: every reward-bearing message in `MessengerDialogTable` (MessageType = Reward) is a subquest completion message, and those rewards are intentionally granted by `/messenger/finsubquest` when the user presses the claim button — not on proceed. A comment documents this instead, so future readers don't try to 'fix' the wrong place (which is exactly how I rediscovered the double-grant: granting on proceed *and* on claim).

## Test

- Completed subquest 1061 end-to-end in game: end conversation plays, claim button grants the reward once (7050003 ×2)
- Re-claiming after this change returns an empty response and does not grant again