### PR TITLE
fix: record CampaignGroupClear trigger when all stages of a group are cleared

### DIFF
--- a/EpinelPS/LobbyServer/Stage/ClearStage.cs
+++ b/EpinelPS/LobbyServer/Stage/ClearStage.cs
@@ -1,4 +1,4 @@
-﻿using EpinelPS.Data;
+using EpinelPS.Data;
 using EpinelPS.Database;
 using EpinelPS.Utils;
 
@@ -151,6 +151,20 @@ public class ClearStage : LobbyMessage
             user.FieldInfoNew.Add(stageMapId, new FieldInfoNew());
 
         user.FieldInfoNew[stageMapId].CompletedStages.Add(StageId);
+
+        // Subquests like Tetra Connect require clearing every stage of a stage
+        // group, the client waits for this trigger to play the ending scenario.
+        if (clearedStage.GroupId != 0 &&
+            !GameContext.Instance.Triggers.Any(t => t.UserId == user.ID && t.Type == Trigger.CampaignGroupClear && t.ConditionId == clearedStage.GroupId))
+        {
+            bool groupCleared = GameData.Instance.StageDataRecords.Values
+                .Where(s => s.GroupId == clearedStage.GroupId)
+                .All(s => user.FieldInfoNew.Values.Any(f => f.CompletedStages.Contains(s.Id)));
+
+            if (groupCleared)
+                user.AddTrigger(Trigger.CampaignGroupClear, 1, clearedStage.GroupId);
+        }
+
         JsonDb.Save();
         return response;
     }


### PR DESCRIPTION
## Problem

Battle subquests whose clear condition is `CampaignGroupClear` (e.g. the Tetra Connect commission, subquest 1031, requiring stage group 2001 = stages 6002017 + 6002018) can never be completed: the server records `CampaignStart`/`CampaignClear` per stage, but never records `Trigger.CampaignGroupClear`. The client waits for that trigger to play the ending scenario and report the subquest as complete, so after winning every required battle nothing happens — no ending cutscene, no completion.

This affects 60+ subquests (every `SubQuestTable` entry with `ClearTrigger = CampaignGroupClear`, groups 2001–1032003).

## Fix

After marking a stage as completed in `ClearStage.CompleteStage`, check whether every stage sharing its `GroupId` is now cleared. If so, record `Trigger.CampaignGroupClear` once (guarded against duplicates on stage replays). The client picks it up through `/trigger/sync` and continues the subquest flow: ending scenario → end messenger conversation → reward claim.

## Test

- Subquest 1031 (Tetra Connect): after clearing both group-2001 battles with this change, the client received the trigger via `/trigger/sync`, played the ending scenario, completed the subquest, and the reward (7051007 ×2) was claimable through the end conversation
- Subquest 1091 (group 3001, three stages): trigger fired automatically exactly when the last remaining stage (6003008) was cleared — no manual intervention needed

Verified against static data: group membership was cross-checked with `CampaignStageTable` (e.g. group 2001 = stages 6002017/6002018).