### PR TITLE
fix: record CharacterAttractiveLevelMax trigger so bond-gated outpost sudden events can appear

### DIFF
--- a/EpinelPS/LobbyServer/Character/Counsel/DoCounsel.cs
+++ b/EpinelPS/LobbyServer/Character/Counsel/DoCounsel.cs
@@ -35,6 +35,13 @@ public class DoCounsel : LobbyMessage
                 UpdateAttractiveLevel(currentBondInfo);
             }
 
+            // Outpost events can require a character's attractive level to be maxed
+            if (currentBondInfo.Lv >= user.GetMaxAttractiveLevel(req.NameCode) &&
+                !GameContext.Triggers.Any(t => t.UserId == user.ID && t.Type == Trigger.CharacterAttractiveLevelMax && t.ConditionId == req.NameCode))
+            {
+                user.AddTrigger(Trigger.CharacterAttractiveLevelMax, currentBondInfo.Lv, req.NameCode);
+            }
+
             response.Attractive = currentBondInfo;
             response.Exp = new NetIncreaseExpData
             {

--- a/EpinelPS/LobbyServer/Character/Counsel/Present.cs
+++ b/EpinelPS/LobbyServer/Character/Counsel/Present.cs
@@ -73,6 +73,13 @@ public class Present : LobbyMessage
             UpdateAttractiveLevel(bondInfo);
         }
 
+        // Outpost events can require a character's attractive level to be maxed
+        if (bondInfo.Lv >= user.GetMaxAttractiveLevel(req.NameCode) &&
+            !GameContext.Triggers.Any(t => t.UserId == user.ID && t.Type == Trigger.CharacterAttractiveLevelMax && t.ConditionId == req.NameCode))
+        {
+            user.AddTrigger(Trigger.CharacterAttractiveLevelMax, bondInfo.Lv, req.NameCode);
+        }
+
         response.Attractive = bondInfo;
         response.Exp = new NetIncreaseExpData
         {

--- a/EpinelPS/LobbyServer/Outpost/StartSuddenEvent.cs
+++ b/EpinelPS/LobbyServer/Outpost/StartSuddenEvent.cs
@@ -1,4 +1,5 @@
 using EpinelPS.Data;
+using EpinelPS.Database;
 using EpinelPS.Utils;
 
 namespace EpinelPS.LobbyServer.Outpost;
@@ -32,6 +33,7 @@ public class StartSuddenEvent : LobbyMessage
         };
 
         user.ClearedOutpostScenarioIds.Add(suddenEvent.Id);
+        JsonDb.Save();
 
         await WriteDataAsync(response);
     }


### PR DESCRIPTION
## Problem

Outpost sudden events are evaluated **client-side**: the client combines the static `OutpostConditionTriggerTable` with the trigger history it receives from `/trigger/sync`. One event, `d_ex_command_06`, requires both Blanc and Noir at max attractive level (`Trigger.CharacterAttractiveLevelMax`, condition value 10). The server never records this trigger anywhere, so the condition can never be satisfied and the event can never appear.

## Fix

- `Present.cs` / `DoCounsel.cs` (the two attractive level-up paths): once a character reaches their attractive level cap, record `Trigger.CharacterAttractiveLevelMax` with `ConditionId = NameCode` and `Value = level` (deduplicated, so replays/re-counsels don't spam the trigger log).
- `StartSuddenEvent.cs`: persist the cleared event id with `JsonDb.Save()`. Previously the cleared state lived only in memory and was lost if the server restarted before another handler happened to save, letting a completed event reappear and consume stamina again.

## Test

Verified end-to-end in game (client 150.6.9):

1. Counseled Blanc and Noir to the attractive level cap → server recorded `(76, 5008, 10)` and `(76, 5009, 10)`
2. Client received both via `/trigger/sync`
3. `d_ex_command_06` icon appeared on the command center
4. Separately, the elevator event (`d_ex_elevator_01`) completed normally: reward granted, stamina consumed, cleared id persisted