### PR TITLE
feat: implement jukebox song unlocks, playlists and BGM settings

### DIFF
--- a/EpinelPS/LobbyServer/Controllers/LobbyController.cs
+++ b/EpinelPS/LobbyServer/Controllers/LobbyController.cs
@@ -1,4 +1,4 @@
-﻿using EpinelPS.Data;
+using EpinelPS.Data;
 using EpinelPS.Database;
 using EpinelPS.Interfaces;
 using EpinelPS.Utils;
@@ -47,6 +47,8 @@ public class LobbyController(IUserService UserService, GameContext db) : Control
 
             Jukeboxv2 = new NetUserJukeboxDataV2() { CommandBgm = new NetJukeboxBgm() { JukeboxTableId = user.CommanderMusic.TableId, Type = NetJukeboxBgmType.JukeboxTableId, Location = NetJukeboxLocation.CommanderRoom } }
         };
+
+        response.Jukeboxv2.JukeboxTableIds.AddRange(JukeboxUtils.GetUnlockedSongs(user));
 
 
 

--- a/EpinelPS/LobbyServer/Jukebox/FavoriteAddSong.cs
+++ b/EpinelPS/LobbyServer/Jukebox/FavoriteAddSong.cs
@@ -1,0 +1,25 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/favorite/addsong")]
+public class AddJukeboxFavoriteSong : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqAddJukeboxFavoriteSong req = await ReadData<ReqAddJukeboxFavoriteSong>();
+        User user = GetUser();
+
+        if (!user.FavoriteSongs.Songs.Any(s => s.JukeboxTableId == req.JukeboxTableId))
+        {
+            user.FavoriteSongs.Songs.Add(new NetJukeboxPlaylistSong
+            {
+                JukeboxTableId = req.JukeboxTableId,
+                Order = user.FavoriteSongs.Songs.Count == 0 ? 1 : user.FavoriteSongs.Songs.Max(s => s.Order) + 1
+            });
+            JsonDb.Save();
+        }
+
+        await WriteDataAsync(new ResAddJukeboxFavoriteSong { FavoriteSongs = user.FavoriteSongs });
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/FavoriteSetSongs.cs
+++ b/EpinelPS/LobbyServer/Jukebox/FavoriteSetSongs.cs
@@ -1,0 +1,33 @@
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/favorite/set")]
+public class SetJukeboxFavoriteSongs : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSetJukeboxFavoriteSongs req = await ReadData<ReqSetJukeboxFavoriteSongs>();
+        User user = GetUser();
+
+        user.FavoriteSongs.Songs.Clear();
+        user.FavoriteSongs.Songs.AddRange(req.Songs);
+        JsonDb.Save();
+
+        ResSetJukeboxFavoriteSongs response = new() { FavoriteSongs = user.FavoriteSongs };
+
+        // if favorites are set as BGM somewhere, its contents changed
+        foreach (var location in new[] { NetJukeboxLocation.Lobby, NetJukeboxLocation.CommanderRoom })
+        {
+            var setting = location == NetJukeboxLocation.Lobby ? user.LobbyMusic : user.CommanderMusic;
+            if (setting.Type == NetJukeboxBgmType.JukeboxFavorite)
+            {
+                response.JukeboxBgm.Add(JukeboxUtils.BuildCurrentBgm(user, location));
+                break;
+            }
+        }
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/PlaylistAddSong.cs
+++ b/EpinelPS/LobbyServer/Jukebox/PlaylistAddSong.cs
@@ -1,0 +1,28 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/playlist/addsong")]
+public class AddSongJukeboxPlaylist : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqAddSongJukeboxPlaylist req = await ReadData<ReqAddSongJukeboxPlaylist>();
+        User user = GetUser();
+
+        ResAddSongJukeboxPlaylist response = new();
+        var playlist = user.PlayLists.FirstOrDefault(p => p.JukeboxPlaylistUid == req.JukeboxPlaylistUid);
+        if (playlist != null && !playlist.Songs.Any(s => s.JukeboxTableId == req.JukeboxTableId))
+        {
+            playlist.Songs.Add(new NetJukeboxPlaylistSong
+            {
+                JukeboxTableId = req.JukeboxTableId,
+                Order = playlist.Songs.Count == 0 ? 1 : playlist.Songs.Max(s => s.Order) + 1
+            });
+            JsonDb.Save();
+            response.Playlist = playlist;
+        }
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/PlaylistCreate.cs
+++ b/EpinelPS/LobbyServer/Jukebox/PlaylistCreate.cs
@@ -1,0 +1,23 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/playlist/create")]
+public class CreateJukeboxPlaylist : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqCreateJukeboxPlaylist req = await ReadData<ReqCreateJukeboxPlaylist>();
+        User user = GetUser();
+
+        var playlist = new NetJukeboxPlaylist
+        {
+            JukeboxPlaylistUid = user.PlayLists.Count == 0 ? 1 : user.PlayLists.Max(p => p.JukeboxPlaylistUid) + 1,
+            Title = req.Title
+        };
+        user.PlayLists.Add(playlist);
+        JsonDb.Save();
+
+        await WriteDataAsync(new ResCreateJukeboxPlaylist { Playlist = playlist });
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/PlaylistDelete.cs
+++ b/EpinelPS/LobbyServer/Jukebox/PlaylistDelete.cs
@@ -1,0 +1,38 @@
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/playlist/delete")]
+public class DeleteJukeboxPlaylist : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqDeleteJukeboxPlaylist req = await ReadData<ReqDeleteJukeboxPlaylist>();
+        User user = GetUser();
+
+        ResDeleteJukeboxPlaylist response = new();
+        var playlist = user.PlayLists.FirstOrDefault(p => p.JukeboxPlaylistUid == req.JukeboxPlaylistUid);
+        if (playlist != null)
+        {
+            user.PlayLists.Remove(playlist);
+
+            // reset any location whose BGM was this playlist back to its default song
+            foreach (var location in new[] { NetJukeboxLocation.Lobby, NetJukeboxLocation.CommanderRoom })
+            {
+                var setting = location == NetJukeboxLocation.Lobby ? user.LobbyMusic : user.CommanderMusic;
+                if (setting.Type == NetJukeboxBgmType.JukeboxPlaylist && setting.TableId == req.JukeboxPlaylistUid)
+                {
+                    setting.Type = NetJukeboxBgmType.JukeboxTableId;
+                    setting.TableId = location == NetJukeboxLocation.Lobby ? 2 : 5;
+                    setting.IsShuffle = false;
+                    response.JukeboxBgm.Add(JukeboxUtils.BuildCurrentBgm(user, location));
+                }
+            }
+
+            JsonDb.Save();
+        }
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/PlaylistSet.cs
+++ b/EpinelPS/LobbyServer/Jukebox/PlaylistSet.cs
@@ -1,0 +1,37 @@
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/playlist/set")]
+public class SetJukeboxPlaylist : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSetJukeboxPlaylist req = await ReadData<ReqSetJukeboxPlaylist>();
+        User user = GetUser();
+
+        ResSetJukeboxPlaylist response = new();
+        var playlist = user.PlayLists.FirstOrDefault(p => p.JukeboxPlaylistUid == req.JukeboxPlaylistUid);
+        if (playlist != null)
+        {
+            playlist.Songs.Clear();
+            playlist.Songs.AddRange(req.Songs);
+            JsonDb.Save();
+            response.Playlist = playlist;
+
+            // if this playlist is set as BGM somewhere, its contents changed
+            foreach (var location in new[] { NetJukeboxLocation.Lobby, NetJukeboxLocation.CommanderRoom })
+            {
+                var setting = location == NetJukeboxLocation.Lobby ? user.LobbyMusic : user.CommanderMusic;
+                if (setting.Type == NetJukeboxBgmType.JukeboxPlaylist && setting.TableId == req.JukeboxPlaylistUid)
+                {
+                    response.JukeboxBgm.Add(JukeboxUtils.BuildCurrentBgm(user, location));
+                    break;
+                }
+            }
+        }
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/PlaylistSetTitle.cs
+++ b/EpinelPS/LobbyServer/Jukebox/PlaylistSetTitle.cs
@@ -1,0 +1,24 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/playlist/settitle")]
+public class SetJukeboxPlaylistTitle : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSetJukeboxPlaylistTitle req = await ReadData<ReqSetJukeboxPlaylistTitle>();
+        User user = GetUser();
+
+        ResSetJukeboxPlaylistTitle response = new();
+        var playlist = user.PlayLists.FirstOrDefault(p => p.JukeboxPlaylistUid == req.JukeboxPlaylistUid);
+        if (playlist != null)
+        {
+            playlist.Title = req.Title;
+            JsonDb.Save();
+            response.Playlist = playlist;
+        }
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/SetBgmFavorite.cs
+++ b/EpinelPS/LobbyServer/Jukebox/SetBgmFavorite.cs
@@ -1,0 +1,20 @@
+using EpinelPS.Database;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/set/favorite")]
+public class SetJukeboxBgmFavorite : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSetJukeboxBgmFavorite req = await ReadData<ReqSetJukeboxBgmFavorite>();
+        User user = GetUser();
+
+        var setting = req.Location == NetJukeboxLocation.Lobby ? user.LobbyMusic : user.CommanderMusic;
+        setting.Type = NetJukeboxBgmType.JukeboxFavorite;
+        setting.IsShuffle = req.IsShuffle;
+        JsonDb.Save();
+
+        await WriteDataAsync(new ResSetJukeboxBgmFavorite());
+    }
+}

--- a/EpinelPS/LobbyServer/Jukebox/SetBgmPlaylist.cs
+++ b/EpinelPS/LobbyServer/Jukebox/SetBgmPlaylist.cs
@@ -1,0 +1,25 @@
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Jukebox;
+
+[GameRequest("/jukebox/set/playlist")]
+public class SetJukeboxBgmPlaylist : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqSetJukeboxBgmPlaylist req = await ReadData<ReqSetJukeboxBgmPlaylist>();
+        User user = GetUser();
+
+        var setting = req.Location == NetJukeboxLocation.Lobby ? user.LobbyMusic : user.CommanderMusic;
+        if (user.PlayLists.Any(p => p.JukeboxPlaylistUid == req.JukeboxPlaylistUid))
+        {
+            setting.Type = NetJukeboxBgmType.JukeboxPlaylist;
+            setting.TableId = (int)req.JukeboxPlaylistUid;
+            setting.IsShuffle = req.IsShuffle;
+            JsonDb.Save();
+        }
+
+        await WriteDataAsync(new ResSetJukeboxBgmPlaylist());
+    }
+}

--- a/EpinelPS/LobbyServer/LobbyUser/GetWallpaper.cs
+++ b/EpinelPS/LobbyServer/LobbyUser/GetWallpaper.cs
@@ -1,4 +1,6 @@
-﻿namespace EpinelPS.LobbyServer.LobbyUser;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.LobbyUser;
 
 [GameRequest("/User/GetWallpaper")]
 public class GetWallpaper : LobbyMessage
@@ -17,7 +19,7 @@ public class GetWallpaper : LobbyMessage
         response.WallpaperFavoriteList.AddRange(user.WallpaperFavoriteList);
         response.OwnedLobbyDecoBackgroundIdList.AddRange(user.LobbyDecoBackgroundList);
 
-        // TODO: JukeboxIdList
+        response.JukeboxIdList.AddRange(JukeboxUtils.GetUnlockedSongs(user));
 
         await WriteDataAsync(response);
     }

--- a/EpinelPS/LobbyServer/Mission/Rewards/GetJukeboxRewards.cs
+++ b/EpinelPS/LobbyServer/Mission/Rewards/GetJukeboxRewards.cs
@@ -1,4 +1,4 @@
-﻿namespace EpinelPS.LobbyServer.Mission.Rewards;
+namespace EpinelPS.LobbyServer.Mission.Rewards;
 
 [GameRequest("/mission/getrewarded/jukebox")]
 public class GetJukeboxRewards : LobbyMessage
@@ -6,9 +6,11 @@ public class GetJukeboxRewards : LobbyMessage
     protected override async Task HandleAsync()
     {
         ReqGetJukeboxRewardedData req = await ReadData<ReqGetJukeboxRewardedData>();
+        User user = GetUser();
 
-        // TODO: save these things
+        // Tell the client which jukebox milestone rewards were already claimed
         ResGetJukeboxRewardedData response = new();
+        response.JukeboxMissionTidList.AddRange(user.ClaimedJukeboxRewardTriggers);
 
         await WriteDataAsync(response);
     }

--- a/EpinelPS/LobbyServer/Outpost/GetOutpostData.cs
+++ b/EpinelPS/LobbyServer/Outpost/GetOutpostData.cs
@@ -1,4 +1,4 @@
-﻿using EpinelPS.Data;
+using EpinelPS.Data;
 using EpinelPS.Database;
 using EpinelPS.Utils;
 namespace EpinelPS.LobbyServer.Outpost;
@@ -38,11 +38,8 @@ public class GetOutpostData : LobbyMessage
         //response.JukeboxV2.JukeboxTableIds.AddRange([5, 9999901, 4001, 4002, 4003, 4004, 4005, 4006, 12, 4007, 4008, 4009, 4010, 4011, 4012, 4013, 4014, 4015, 4016, 4017, 4018, 4019, 4020, 4021, 4022, 4023, 4024, 4025, 4026, 4027, 4028, 4029, 4030, 4031, 4032, 4033, 4034, 4036, 5001, 5002, 5003, 5004, 5005, 5006, 5007, 5008, 5009, 5010, 5011, 5012]);
 
 
-        // Directly use jukeboxListDataRecords
-        List<int> jukeboxIds = [.. GameData.Instance.jukeboxListDataRecords.Keys];
-
-        // Update response lists with the IDs
-        response.Jukeboxv2.JukeboxTableIds.AddRange(jukeboxIds);
+        // Send default songs plus songs the user has unlocked
+        response.Jukeboxv2.JukeboxTableIds.AddRange(JukeboxUtils.GetUnlockedSongs(user));
 
         response.OutpostBattleLevel = user.OutpostBattleLevel;
         response.OutpostBattleTime = new NetOutpostBattleTime() { MaxBattleTime = 864000000000, MaxOverBattleTime = 12096000000000, BattleTime = battleTimeMs, OverBattleTime = overBattleTime };

--- a/EpinelPS/LobbyServer/Outpost/JukeboxGet.cs
+++ b/EpinelPS/LobbyServer/Outpost/JukeboxGet.cs
@@ -5,22 +5,15 @@ public class JukeboxPlaylistGet : LobbyMessage
 {
     protected override async Task HandleAsync()
     {
-        // Prepare response with static data
+        ReqGetJukeboxPlaylist req = await ReadData<ReqGetJukeboxPlaylist>();
+        User user = GetUser();
+
         ResGetJukeboxPlaylist response = new()
         {
-            Playlists = { }, // Assuming Playlists is a list or similar collection type, you may want to add items here.
-            FavoriteSongs = new NetJukeboxFavorite
-            {
-                Songs =
-                {
-                    new NetJukeboxPlaylistSong { JukeboxTableId = 8995001,Order = 899 },
-                    new NetJukeboxPlaylistSong { JukeboxTableId = 9020001, Order = 902 }
-                }
-            },
-            // JukeboxPlaylistUId = 123456789 // Assign a static UID, if required
+            FavoriteSongs = user.FavoriteSongs
         };
+        response.Playlists.AddRange(user.PlayLists);
 
-        // Send the response
         await WriteDataAsync(response);
     }
 }

--- a/EpinelPS/LobbyServer/Trigger/ObtainTriggerRewardForJukebox.cs
+++ b/EpinelPS/LobbyServer/Trigger/ObtainTriggerRewardForJukebox.cs
@@ -1,0 +1,44 @@
+using EpinelPS.Data;
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.TriggerController;
+
+[GameRequest("/Trigger/ObtainTriggerRewardForJukebox")]
+public class ObtainTriggerRewardForJukebox : LobbyMessage
+{
+    protected override async Task HandleAsync()
+    {
+        ReqObtainTriggerRewardForJukebox req = await ReadData<ReqObtainTriggerRewardForJukebox>();
+        User user = GetUser();
+
+        ResObtainTriggerRewardForJukebox response = new();
+        List<NetRewardData> rewards = [];
+
+        foreach (var tid in req.TidList.Distinct())
+        {
+            // give only rewards for milestones that were achieved and not claimed already
+            if (user.ClaimedJukeboxRewardTriggers.Contains(tid))
+                continue;
+            if (!GameData.Instance.TriggerTable.TryGetValue(tid, out var trigger))
+                continue;
+            if (trigger.Trigger != Trigger.ObtainJukeboxTheme)
+                continue;
+            if (JukeboxUtils.CountOwnedSongsByTheme(user, trigger.ConditionId) < trigger.ConditionValue)
+                continue;
+
+            RewardRecord? reward = GameData.Instance.GetRewardTableEntry(trigger.RewardId);
+            if (reward == null)
+                continue;
+
+            rewards.Add(RewardUtils.RegisterRewardsForUser(user, reward));
+            user.ClaimedJukeboxRewardTriggers.Add(tid);
+        }
+
+        response.Reward = NetUtils.MergeRewards(rewards, user);
+
+        JsonDb.Save();
+
+        await WriteDataAsync(response);
+    }
+}

--- a/EpinelPS/Models/DbModels.cs
+++ b/EpinelPS/Models/DbModels.cs
@@ -324,6 +324,7 @@ public class JukeBoxSetting
     public NetJukeboxLocation Location { get; set; }
     public NetJukeboxBgmType Type { get; set; }
     public int TableId { get; set; }
+    public bool IsShuffle { get; set; }
 }
 
 public class UnlockData

--- a/EpinelPS/Models/UserModel.cs
+++ b/EpinelPS/Models/UserModel.cs
@@ -108,6 +108,7 @@ public class User
 
     public List<int> Memorial { get; set; } = [];
     public List<int> JukeboxBgm { get; set; } = [];
+    public List<int> ClaimedJukeboxRewardTriggers { get; set; } = [];
     public List<NetUserFavoriteItemData> FavoriteItems { get; set; } = [];
 
     public List<NetUserFavoriteItemQuestData> FavoriteItemQuests { get; set; } = [];

--- a/EpinelPS/Utils/JukeboxUtils.cs
+++ b/EpinelPS/Utils/JukeboxUtils.cs
@@ -1,0 +1,71 @@
+using EpinelPS.Data;
+using EpinelPS.Models;
+
+namespace EpinelPS.Utils;
+
+public static class JukeboxUtils
+{
+    /// <summary>
+    /// Songs available to the user: default BGMs plus everything unlocked
+    /// (unlocks are granted through RewardType.Bgm rewards, e.g. field items).
+    /// </summary>
+    public static List<int> GetUnlockedSongs(User user)
+    {
+        var owned = new HashSet<int>(user.JukeboxBgm);
+        var result = new List<int>();
+        foreach (var song in GameData.Instance.jukeboxListDataRecords.Values)
+        {
+            if (song.IsDefaultBgm || owned.Contains(song.Id))
+                result.Add(song.Id);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Number of songs of a theme the user owns (default BGMs included).
+    /// </summary>
+    public static int CountOwnedSongsByTheme(User user, int theme)
+    {
+        var owned = new HashSet<int>(user.JukeboxBgm);
+        int count = 0;
+        foreach (var song in GameData.Instance.jukeboxListDataRecords.Values)
+        {
+            if (song.Theme != theme)
+                continue;
+            if (song.IsDefaultBgm || owned.Contains(song.Id))
+                count++;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Builds the client's view of the current BGM setting for a location.
+    /// </summary>
+    public static NetJukeboxBgm BuildCurrentBgm(User user, NetJukeboxLocation location)
+    {
+        var setting = location == NetJukeboxLocation.Lobby ? user.LobbyMusic : user.CommanderMusic;
+        var bgm = new NetJukeboxBgm { Location = location, Type = setting.Type, IsShuffle = setting.IsShuffle };
+        switch (setting.Type)
+        {
+            case NetJukeboxBgmType.JukeboxPlaylist:
+                var playlist = user.PlayLists.FirstOrDefault(p => p.JukeboxPlaylistUid == setting.TableId);
+                if (playlist != null)
+                {
+                    bgm.JukeboxPlaylist = playlist;
+                }
+                else
+                {
+                    bgm.Type = NetJukeboxBgmType.JukeboxTableId;
+                    bgm.JukeboxTableId = setting.TableId;
+                }
+                break;
+            case NetJukeboxBgmType.JukeboxFavorite:
+                bgm.JukeboxFavorite = user.FavoriteSongs;
+                break;
+            default:
+                bgm.JukeboxTableId = setting.TableId;
+                break;
+        }
+        return bgm;
+    }
+}


### PR DESCRIPTION
## Summary

The jukebox was mostly stubbed out: the client received either every song (GetOutpostData sent all 876) or an empty list (EnterLobbyServer), the lobby decoration BGM UI had no song list (TODO in GetWallpaper), and most playlist/favorite endpoints had no handler (logged as "No handler for: /jukebox/playlist/create" etc.).

## Changes

- **Song unlock list**: new `JukeboxUtils.GetUnlockedSongs` (default BGMs + songs in `User.JukeboxBgm`, which are unlocked through existing `RewardType.Bgm` rewards e.g. field items). Used by GetOutpostData, EnterLobbyServer and GetWallpaper (`JukeboxIdList`).
- **Milestone rewards**: implement `/Trigger/ObtainTriggerRewardForJukebox` — validates `ObtainJukeboxTheme` trigger milestones (e.g. "collect N songs of theme X") against owned song counts, grants the configured reward, and tracks claims in `User.ClaimedJukeboxRewardTriggers`. Claimed milestones are returned by `/mission/getrewarded/jukebox` so the client remembers them.
- **Playlists**: implement `/jukebox/playlist/create`, `/set`, `/addsong`, `/settitle`, `/delete`, persisted on `User.PlayLists`.
- **Favorites**: implement `/jukebox/favorite/set`, `/jukebox/favorite/addsong`, persisted on `User.FavoriteSongs`.
- **BGM settings**: implement `/jukebox/set/playlist` and `/jukebox/set/favorite` (per location: lobby / commander room), persisting the shuffle flag on `JukeBoxSetting` (new `IsShuffle` field). Deleting a playlist that is set as BGM resets that location to its default song.
- **`/jukebox/playlist/get`** returns the user's real playlists and favorites instead of hardcoded entries.

## Testing

Verified in-game on a local server: song list shows partial unlocks, milestone rewards can be claimed once, setting BGM by song/playlist/favorite works for both commander room and lobby (including per-wallpaper songs in the lobby decoration UI).
