### PR TITLE
fix: keep GameContext.Instance alive for the app's lifetime

### DIFF
--- a/EpinelPS/Database/GameContext.cs
+++ b/EpinelPS/Database/GameContext.cs
@@ -22,10 +22,17 @@ public class GameContext : DbContext
 
     /// <summary>
     /// GameContext instance. Should only be used in console thread.
+    /// Long-lived, set once at startup via <see cref="SetInstance"/> - do NOT set this from
+    /// the constructor, as DI creates short-lived scoped instances per request that get
+    /// disposed when the request ends, leaving a dangling disposed instance behind.
     /// </summary>
     public static GameContext Instance { get; private set; } = null!;
     public GameContext(DbContextOptions<GameContext> options) : base(options)
     {
-        Instance = this;
+    }
+
+    public static void SetInstance(GameContext context)
+    {
+        Instance = context;
     }
 }

--- a/EpinelPS/Program.cs
+++ b/EpinelPS/Program.cs
@@ -126,6 +126,12 @@ internal class Program
 
             WebApplication app = builder.Build();
             CreateDbIfNotExists(app);
+
+            // Long-lived GameContext for legacy code paths that use GameContext.Instance
+            // (e.g. User.AddTrigger). Resolved from the root provider so it is never
+            // disposed before shutdown, unlike per-request scoped instances.
+            GameContext.SetInstance(app.Services.GetRequiredService<GameContext>());
+
             app.UseDefaultFiles();
             app.UseStaticFiles();
             app.UseMiddleware<EncryptionMiddleware>();


### PR DESCRIPTION
## Problem

`GameContext` is registered with `AddDbContext` (scoped lifetime), and its constructor assigned **every** scoped instance to the static `Instance` property. When a request-scoped instance is disposed at the end of a request, `Instance` is left pointing at a disposed context. Any later use throws:

```
System.ObjectDisposedException: Cannot access a disposed context instance.
Object name: 'GameContext'.
   at EpinelPS.Models.User.AddTrigger(Trigger type, Int32 value, Int32 conditionId)
   at EpinelPS.Utils.RewardUtils.AddSingleObject(...)
```

A user-visible symptom: when picking up a jukebox BGM field item, `AddSingleObject` adds the song and then throws inside `AddTrigger`. The client retries automatically, but on retry the song is already recorded, so the reward branch is skipped and the response carries an **empty `JukeboxBgm` list** - the pickup popup then renders as a placeholder with a silent play button, while the song is still unlocked server-side. This affects every reward path that calls `AddTrigger`.

## Fix

Stop assigning `Instance` from the constructor. Set it once at startup via `GameContext.SetInstance` from the root service provider, so the instance is never disposed before shutdown. Per-request scoped contexts are unaffected.